### PR TITLE
Implement receiver methods for SQS.

### DIFF
--- a/src/Service/Sqs/SqsReceivedStamp.php
+++ b/src/Service/Sqs/SqsReceivedStamp.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service\Sqs;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+final class SqsReceivedStamp implements NonSendableStampInterface
+{
+    private string $receiptHandle;
+
+    public function __construct(string $receiptHandle)
+    {
+        $this->receiptHandle = $receiptHandle;
+    }
+
+    public function getReceiptHandle(): string
+    {
+        return $this->receiptHandle;
+    }
+}

--- a/src/Service/Sqs/SqsReceivedStamp.php
+++ b/src/Service/Sqs/SqsReceivedStamp.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Bref\Symfony\Messenger\Service\Sqs;
 

--- a/src/Service/Sqs/SqsTransport.php
+++ b/src/Service/Sqs/SqsTransport.php
@@ -130,7 +130,7 @@ final class SqsTransport implements TransportInterface
         /** @var SqsReceivedStamp|null $sqsReceivedStamp */
         $sqsReceivedStamp = $envelope->last(SqsReceivedStamp::class);
 
-        if (null === $sqsReceivedStamp) {
+        if ($sqsReceivedStamp === null) {
             throw new LogicException('No SqsReceivedStamp found on the Envelope.');
         }
 


### PR DESCRIPTION
Allow consuming SQS messages via the worker (`messenger:consume`) , to ease local development.