### PR TITLE
deps: allow bref 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/http-kernel": "^4.3 || ^5.0",
         "symfony/yaml": "^4.3 || ^5.0",
-        "bref/bref": "^0.5.18",
+        "bref/bref": "^0.5.18 || ^1.0",
         "async-aws/sns": "^1.0",
         "async-aws/sqs": "^1.2",
         "async-aws/event-bridge": "^1.0"


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Since bref 1.0 has been released today symfony-messenger should be compatible as-is.