### PR TITLE
Rework SQS documentation to be clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ framework:
 
 ### SQS
 
-The [SQS](https://aws.amazon.com/sqs/) service is a queue that works similar to RabbitMQ. To use it, set its URL in the 
-envrionment variable `MESSENGER_TRANSPORT_DSN`:
+The [SQS](https://aws.amazon.com/sqs/) service is a queue that works similar to RabbitMQ. To use it, set its URL in the environment variable `MESSENGER_TRANSPORT_DSN`:
 
 ```dotenv
 MESSENGER_TRANSPORT_DSN=https://sqs.us-east-1.amazonaws.com/123456789/my-queue
@@ -114,7 +113,7 @@ If you use Lift, this is done automatically for you.
 
 #### Consume messages from SQS
 
-1.If you don't use Lift, create the function that will be invoked by SQS in `serverless.yml`:
+1. **If you don't use Lift**, create the function that will be invoked by SQS in `serverless.yml`:
 
 ```yaml
 functions:

--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ To configure **where** messages are dispatched, all the examples in this documen
 framework:
     messenger:
         transports:
-            async: '%env(MESSENGER_TRANSPORT_DSN)%'       
+            async: '%env(MESSENGER_TRANSPORT_DSN)%'
         routing:
              'App\Message\MyMessage': async
 ```
 
 ### SQS
 
-The [SQS](https://aws.amazon.com/sqs/) service is a queue that works similar to RabbitMQ. To use it, set its URL as the `MESSENGER_TRANSPORT_DSN`:
+The [SQS](https://aws.amazon.com/sqs/) service is a queue that works similar to RabbitMQ. To use it, set its URL in the 
+envrionment variable `MESSENGER_TRANSPORT_DSN`:
 
 ```dotenv
 MESSENGER_TRANSPORT_DSN=https://sqs.us-east-1.amazonaws.com/123456789/my-queue

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ should not require any change for dispatching messages.
 You can create the Queue yourself in the Console, write custom Cloudformation 
 or use [Lift's Queue construct](https://github.com/getlift/lift/blob/master/docs/queue.md) that will handle that for you. 
 
-Here is a simple example with Lift, check out the [full documentation](https://github.com/getlift/lift/blob/master/docs/queue.md) for more details.
+Here is a simple example with Lift, make sure to [install the plugin first](https://github.com/getlift/lift#installation) and check out the [full documentation](https://github.com/getlift/lift/blob/master/docs/queue.md) for more details. 
 
 ```yaml
 # serverless.yml


### PR DESCRIPTION
Following https://github.com/brefphp/symfony-messenger/issues/49.

The docs weren't clear about permissions which lead to the issue. 

Here I advise to disable `auto_setup` and set the appropriate permissions. I also took this as an opportunity to suggest using Lift.

Not sure we should keep examples both with and without Lift or just point to external docs when not using Lift.

Let me know what you think.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
