### PR TITLE
Support partial batch failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ services:
         arguments:
             # Pass the transport name used in config/packages/messenger.yaml
             $transportName: 'async'
+            # true enables partial SQS batch failure, see https://bref.sh/docs/function/handlers.html#partial-batch-response for more details.
+            # Enabling this without proper SQS config will consider all your messages successful
+            $partialBatchFailure: false
 ```
 
 Now, anytime a message is dispatched to SQS, the Lambda function will be called. The Bref consumer class will put back the message into Symfony Messenger to be processed.

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ services:
         arguments:
             # Pass the transport name used in config/packages/messenger.yaml
             $transportName: 'async'
-            # true enables partial SQS batch failure, see https://bref.sh/docs/function/handlers.html#partial-batch-response for more details.
+            # true enables partial SQS batch failure
             # Enabling this without proper SQS config will consider all your messages successful
+            # See https://bref.sh/docs/function/handlers.html#partial-batch-response for more details.
             $partialBatchFailure: false
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.3 || ^5.0 || ^6.0",
         "symfony/yaml": "^4.3 || ^5.0 || ^6.0",
-        "bref/bref": "^0.5.18 || ^1.0",
+        "bref/bref": "^1.5",
         "async-aws/sns": "^1.0",
         "async-aws/sqs": "^1.2",
         "async-aws/event-bridge": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "async-aws/sns": "^1.0",
         "async-aws/sqs": "^1.2",
         "async-aws/event-bridge": "^1.0",
-        "symfony/amazon-sqs-messenger": "^5.2 || ^6.0"
+        "symfony/amazon-sqs-messenger": "^5.2 || ^6.0",
+        "symfony/polyfill-php80": "^1.26"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",

--- a/src/Service/Sqs/SqsConsumer.php
+++ b/src/Service/Sqs/SqsConsumer.php
@@ -78,7 +78,8 @@ final class SqsConsumer extends SqsHandler
                     throw $exception;
                 }
 
-                $this->logger->error(sprintf('SQS record with id "%s" failed to be processed. %s', $record->getMessageId(), $exception->getMessage()));
+                $this->logger->error(sprintf('SQS record with id "%s" failed to be processed.', $record->getMessageId()));
+                $this->logger->error($exception->getMessage());
                 $this->markAsFailed($record);
             }
         }

--- a/src/Service/Sqs/SqsConsumer.php
+++ b/src/Service/Sqs/SqsConsumer.php
@@ -7,6 +7,7 @@ use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
 use Bref\Symfony\Messenger\Service\BusDriver;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsXrayTraceHeaderStamp;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -41,7 +42,7 @@ final class SqsConsumer extends SqsHandler
         $this->bus = $bus;
         $this->serializer = $serializer;
         $this->transportName = $transportName;
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
         $this->partialBatchFailure = $partialBatchFailure;
     }
 
@@ -77,10 +78,7 @@ final class SqsConsumer extends SqsHandler
                     throw $exception;
                 }
 
-                if ($this->logger !== null) {
-                    $this->logger->error(sprintf('SQS record with id "%s" failed to be processed. %s', $record->getMessageId(), $exception->getMessage()));
-                }
-
+                $this->logger->error(sprintf('SQS record with id "%s" failed to be processed. %s', $record->getMessageId(), $exception->getMessage()));
                 $this->markAsFailed($record);
             }
         }

--- a/tests/Unit/Service/Sqs/SqsConsumerTest.php
+++ b/tests/Unit/Service/Sqs/SqsConsumerTest.php
@@ -63,6 +63,7 @@ class SqsConsumerTest extends TestCase
                     ],
                     'eventSource'=>'aws:sqs',
                     'messageId' => $messageId,
+                    'eventSourceARN' => 'arn:aws:sqs:us-east-1:123456789012:queue1'
                 ],
             ],
         ]);
@@ -120,6 +121,7 @@ class SqsConsumerTest extends TestCase
                     ],
                     'eventSource'=>'aws:sqs',
                     'messageId' => $messageId,
+                    'eventSourceARN' => 'arn:aws:sqs:us-east-1:123456789012:queue1'
                 ],
             ],
         ]);


### PR DESCRIPTION
 This allows the Symfony Messenger integration to benefit from "partial batch failures" with SQS.

This is done via a new argument in the service declaration (and proper SQS config ofc). 

```diff
Bref\Symfony\Messenger\Service\Sqs\SqsConsumer:
        public: true
        autowire: true
        arguments:
            # Pass the transport name used in config/packages/messenger.yaml
            $transportName: 'async'
+           $partialBatchFailure: true
```

<details>
<summary>
If you want to try this, in `composer.json`
</summary>

```json
{
    "require": {
        ...
        "bref/symfony-messenger": "dev-partial"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/t-richard/symfony-messenger"
        }
    ]
}
```

</details>

Closes #57