### PR TITLE
Update PHPStan and new fix errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.4",
         "mnapoli/hard-mode": "^0.3.0",
-        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan": "^1.7.10",
         "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0",
         "nyholm/symfony-bundle-test": "1.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1"

--- a/src/Service/EventBridge/EventBridgeTransport.php
+++ b/src/Service/EventBridge/EventBridgeTransport.php
@@ -25,7 +25,7 @@ final class EventBridgeTransport implements TransportInterface
     public function __construct(EventBridgeClient $eventBridge, SerializerInterface $serializer, string $source, ?string $eventBusName = null)
     {
         $this->eventBridge = $eventBridge;
-        $this->serializer = $serializer ?? new PhpSerializer;
+        $this->serializer = $serializer;
         $this->source = $source;
         $this->eventBusName = $eventBusName;
     }

--- a/src/Service/Sns/SnsTransport.php
+++ b/src/Service/Sns/SnsTransport.php
@@ -24,7 +24,7 @@ final class SnsTransport implements TransportInterface
     public function __construct(SnsClient $sns, SerializerInterface $serializer, string $topic)
     {
         $this->sns = $sns;
-        $this->serializer = $serializer ?? new PhpSerializer;
+        $this->serializer = $serializer;
         $this->topic = $topic;
     }
 


### PR DESCRIPTION
In #58 the CI failed because of a PHP 8.1 code in vendor. 

The version used by this project is too old to support php 8.1.

This PR updates PHPStan and fixes new errors which are related to variables that can never be null.