### PR TITLE
Feature(sqs): Add xray trace id to enveloppe stamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        php: ['8.0', '7.4', '7.3']
+        php: ['8.0', '7.4']
         dependency-version: ['']
-        include:
-          - php: '7.3'
-            dependency-version: '--prefer-lowest'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "ext-json": "*",
         "symfony/messenger": "^4.3 || ^5.0 || ^6.0",
         "symfony/config": "^4.3 || ^5.0 || ^6.0",

--- a/tests/Unit/Service/Sqs/SqsConsumerTest.php
+++ b/tests/Unit/Service/Sqs/SqsConsumerTest.php
@@ -7,6 +7,8 @@ use Bref\Event\Sqs\SqsEvent;
 use Bref\Symfony\Messenger\Service\BusDriver;
 use Bref\Symfony\Messenger\Service\Sqs\SqsConsumer;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceivedStamp;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsXrayTraceHeaderStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -31,12 +33,19 @@ class SqsConsumerTest extends TestCase
             'Content-Type' => 'application/json',
         ]);
         $body = 'Test message.';
+        $messageId = 'e00c848c-2579-4f6a-a006-ccdc2808ed64';
 
         $serializer->expects($this->once())
             ->method('decode')
             ->with(['body' => $body, 'headers' => $headers])
             ->willReturn(new Envelope(new \stdClass));
-
+        $busDriver->expects($this->once())
+            ->method('putEnvelopeOnBus')
+            ->with($bus, new Envelope(
+                new \stdClass(),
+                [
+                    new AmazonSqsReceivedStamp($messageId),
+                ]), 'async');
         $consumer = new SqsConsumer($busDriver, $bus, $serializer, 'async');
         $event = new SqsEvent([
             'Records' => [
@@ -53,11 +62,68 @@ class SqsConsumerTest extends TestCase
                         ],
                     ],
                     'eventSource'=>'aws:sqs',
-                    'messageId' => 'e00c848c-2579-4f6a-a006-ccdc2808ed64',
+                    'messageId' => $messageId,
                 ],
             ],
         ]);
 
         $consumer->handleSqs($event, new Context('', 0, '', ''));
+    }
+
+    public function testSerializerWithXRayHeader()
+    {
+        $busDriver = $this->getMockBuilder(BusDriver::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['putEnvelopeOnBus'])
+            ->getMock();
+
+        $bus = new MessageBus;
+        $serializer = $this->getMockBuilder(SerializerInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['encode', 'decode'])
+            ->getMock();
+
+        $specialHeaders = ['Special\Header\Name' => 'some data'];
+
+        $headers = array_merge($specialHeaders, [
+            'Content-Type' => 'application/json',
+        ]);
+        $body = 'Test message.';
+        $xrayTraceId = '709857d6-17c2-11ed-861d-0242ac120002';
+        $messageId = 'e00c848c-2579-4f6a-a006-ccdc2808ed64';
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with(['body' => $body, 'headers' => $headers])
+            ->willReturn(new Envelope(new \stdClass));
+        $busDriver->expects($this->once())
+            ->method('putEnvelopeOnBus')
+            ->with($bus, new Envelope(
+                new \stdClass(),
+                [
+                    new AmazonSqsReceivedStamp($messageId),
+                    new AmazonSqsXrayTraceHeaderStamp($xrayTraceId)
+                ]), 'async');
+        $consumer = new SqsConsumer($busDriver, $bus, $serializer, 'async');
+        $event = new SqsEvent([
+            'Records' => [
+                [
+                    'body' => $body,
+                    'messageAttributes' => [
+                        'Content-Type' => [
+                            'dataType' => 'String',
+                            'stringValue' => 'application/json',
+                        ],
+                        'X-Symfony-Messenger' => [
+                            'dataType' => 'String',
+                            'stringValue' => json_encode($specialHeaders),
+                        ],
+                    ],
+                    'eventSource'=>'aws:sqs',
+                    'messageId' => $messageId,
+                ],
+            ],
+        ]);
+
+        $consumer->handleSqs($event, new Context('', 0, '', $xrayTraceId));
     }
 }


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

In order to trace messages with the xray service, i need to fetch trace id from context and propagate it with a messenger stamp.
