### PR TITLE
Add 'or later' to Symfony version advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $kernel->boot();
 return $kernel->getContainer()->get(SqsConsumer::class);
 ```
 
-If you are using Symfony 5.1, use this instead:
+If you are using Symfony 5.1 or later, use this instead:
 
 ```php
 <?php declare(strict_types=1);


### PR DESCRIPTION
Initially I tried the wrong copy / paste snippet because I'm using SF 6, and I wasn't sure if the `5.1` advice was relevant to `>= 5.1` or `<= 5.1`. This change eliminates the confusion and saves 10 minutes of waiting for a new deployment after picking the wrong one... :D 