### PR TITLE
Log whole Exception for UnrecoverableException instead of message only

### DIFF
--- a/src/Service/Sqs/SqsConsumer.php
+++ b/src/Service/Sqs/SqsConsumer.php
@@ -92,7 +92,7 @@ final class SqsConsumer extends SqsHandler
                 $this->busDriver->putEnvelopeOnBus($this->bus, $envelope->with(...$stamps), $this->transportName);
             } catch (UnrecoverableExceptionInterface $exception) {
                 $this->logger->error(sprintf('SQS record with id "%s" failed to be processed. But failure was marked as unrecoverable. Message will be acknowledged.', $record->getMessageId()));
-                $this->logger->error($exception->getMessage());
+                $this->logger->error($exception);
             } catch (\Throwable $exception) {
                 if ($this->partialBatchFailure === false) {
                     throw $exception;


### PR DESCRIPTION
Regarding the issue https://github.com/brefphp/symfony-messenger/issues/76, it would be nice to log the whole Exception in case of the UnrecoverableException. It makes debugging a lot easier.