### PR TITLE
Adds SnsFifoStamp class based of the Symfony base stamp for SQS and a…

### DIFF
--- a/src/Service/Sns/SnsFifoStamp.php
+++ b/src/Service/Sns/SnsFifoStamp.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service\Sns;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+class SnsFifoStamp implements NonSendableStampInterface {
+    private ?string $messageGroupId;
+    private ?string $messageDeduplicationId;
+
+    public function __construct(string $messageGroupId = null, string $messageDeduplicationId = null)
+    {
+        $this->messageGroupId = $messageGroupId;
+        $this->messageDeduplicationId = $messageDeduplicationId;
+    }
+
+    public function getMessageGroupId(): ?string
+    {
+        return $this->messageGroupId;
+    }
+
+    public function getMessageDeduplicationId(): ?string
+    {
+        return $this->messageDeduplicationId;
+    }
+}


### PR DESCRIPTION
Amazon Simple Notification Service (SNS) recently introduced support for First-In-First-Out (FIFO) topics, aligning with the FIFO capabilities of Amazon Simple Queue Service (SQS). More details can be found in the official announcement [here](https://aws.amazon.com/about-aws/whats-new/2023/09/amazon-sns-fifo-topics-message-delivery-sqs-standard-queues/).

This PR introduces the following enhancements:

- Introduces the `Bref\Symfony\Messenger\Service\Sns\SnsFifoStamp` class, allowing the setting of `messageGroupId` and `messageDeduplicationId` for messages sent to SNS FIFO topics, similar to the existing Symfony `SqsFifoStamp` class.
- Adds logic to detect if an SNS topic is FIFO-enabled (by checking the '.fifo' suffix in the topic name) and automatically apply the `SnsFifoStamp` to messages, ensuring the necessary parameters are set before publishing.

These enhancements facilitate the creation of an SNS FIFO topic with fan-out capabilities to multiple SQS FIFO queues using AWS CDK, improving message ordering and deduplication. Note that when using AWS CDK for setting up such infrastructure, specifying the `messageGroupId` for the SNS topic is mandatory.
