### PR TITLE
Added TransportNameResolver for sns and sqs for automatic transport r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ services:
         public: true
         autowire: true
         arguments:
-            # Pass the transport name used in config/packages/messenger.yaml
-            $transportName: 'async'
             # true enables partial SQS batch failure
             # Enabling this without proper SQS config will consider all your messages successful
             # See https://bref.sh/docs/function/handlers.html#partial-batch-response for more details.
@@ -296,9 +294,6 @@ services:
     Bref\Symfony\Messenger\Service\Sns\SnsConsumer:
         public: true
         autowire: true
-        arguments:
-            # Pass the transport name used in config/packages/messenger.yaml
-            $transportName: 'async'
 ```
 
 Now, anytime a message is dispatched to SNS, the Lambda function will be called. The Bref consumer class will put back the message into Symfony Messenger to be processed.
@@ -390,7 +385,6 @@ services:
         public: true
         autowire: true
         arguments:
-            # Pass the transport name used in config/packages/messenger.yaml
             $transportName: 'async'
             # Optionnally, if you have different buses in config/packages/messenger.yaml, set $bus like below:
             # $bus: '@event.bus'
@@ -456,6 +450,34 @@ services:
                 region: us-east-1
 ```
 
+### Automatic transport recognition
+
+Automatic transport recognition is primarily handled by default through TransportNameResolvers for SNS and SQS,
+ensuring that the transport name is automatically passed to your message handlers.
+However, in scenarios where you need to manually specify the transport name or adjust the default behavior,
+you can do so by setting the `$transportName` parameter in your service definitions within the config/services.yaml file.
+This parameter should match the transport name defined in your config/packages/messenger.yaml.
+For instance, for a SNSConsumer, you would configure it as follows:
+
+```yaml
+# config/packages/messenger.yaml
+framework:
+  messenger:
+    transports:
+      async: '%env(MESSENGER_TRANSPORT_DSN)%'
+```
+
+```yaml
+# config/services.yaml
+services:
+    Bref\Symfony\Messenger\Service\Sns\SnsConsumer:
+        public: true
+        autowire: true
+        arguments:
+            # Pass the transport name used in config/packages/messenger.yaml
+            $transportName: 'async'
+```
+
 ### Disabling transports
 
 By default, this package registers Symfony Messenger transports for SQS, SNS and EventBridge.
@@ -481,6 +503,5 @@ services:
         public: true
         autowire: true
         arguments:
-            $transportName: 'async'
             $serializer: '@Happyr\MessageSerializer\Serializer'
 ```

--- a/src/DependencyInjection/BrefMessengerExtension.php
+++ b/src/DependencyInjection/BrefMessengerExtension.php
@@ -4,14 +4,26 @@ namespace Bref\Symfony\Messenger\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class BrefMessengerExtension extends Extension
+class BrefMessengerExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $configs = $container->getExtensionConfig('framework');
+
+        foreach (array_reverse($configs) as $config) {
+            if (array_key_exists('messenger', $config)) {
+                $container->setParameter('messenger.transports', $config['messenger']['transports']);
+            }
+        }
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -4,13 +4,25 @@ services:
         arguments:
             - '@logger'
 
+    Bref\Symfony\Messenger\Service\MessengerTransportConfiguration:
+        arguments:
+            $messengerTransportsConfiguration: '%messenger.transports%'
+
     # SNS
+    Bref\Symfony\Messenger\Service\Sns\SnsTransportNameResolver:
+        arguments:
+            - '@Bref\Symfony\Messenger\Service\MessengerTransportConfiguration'
     Bref\Symfony\Messenger\Service\Sns\SnsTransportFactory:
         tags: ['messenger.transport_factory']
         arguments:
             - '@bref.messenger.sns_client'
     bref.messenger.sns_client:
         class: AsyncAws\Sns\SnsClient
+
+    # SQS
+    Bref\Symfony\Messenger\Service\Sqs\SqsTransportNameResolver:
+        arguments:
+            - '@Bref\Symfony\Messenger\Service\MessengerTransportConfiguration'
 
     # EventBridge
     Bref\Symfony\Messenger\Service\EventBridge\EventBridgeTransportFactory:

--- a/src/Service/MessengerTransportConfiguration.php
+++ b/src/Service/MessengerTransportConfiguration.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service;
+
+use InvalidArgumentException;
+
+/** @final */
+class MessengerTransportConfiguration
+{
+    public function __construct(
+        private array $messengerTransportsConfiguration
+    ) {
+    }
+
+    /** @throws InvalidArgumentException */
+    public function provideTransportFromEventSource(string $eventSourceWithProtocol): string
+    {
+        foreach ($this->messengerTransportsConfiguration as $messengerTransport => $messengerOptions) {
+            $dsn = $this->extractDsnFromTransport($messengerOptions);
+
+            if ($dsn === $eventSourceWithProtocol) {
+                return $messengerTransport;
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf('No transport found for eventSource "%s".', $eventSourceWithProtocol));
+    }
+
+    private function extractDsnFromTransport(string|array $messengerTransport): string
+    {
+        if (is_array($messengerTransport) && array_key_exists('dsn', $messengerTransport)) {
+            return $messengerTransport['dsn'];
+        }
+
+        return $messengerTransport;
+    }
+}

--- a/src/Service/Sns/SnsConsumer.php
+++ b/src/Service/Sns/SnsConsumer.php
@@ -5,7 +5,9 @@ namespace Bref\Symfony\Messenger\Service\Sns;
 use Bref\Context\Context;
 use Bref\Event\Sns\SnsEvent;
 use Bref\Event\Sns\SnsHandler;
+use Bref\Event\Sns\SnsRecord;
 use Bref\Symfony\Messenger\Service\BusDriver;
+use LogicException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -15,19 +17,19 @@ final class SnsConsumer extends SnsHandler
     private $bus;
     /** @var SerializerInterface */
     protected $serializer;
-    /** @var SnsTransportNameResolver */
-    private $transportNameResolver;
-    /** @var BusDriver */
-    private $busDriver;
     /** @var string|null */
     private $transportName;
+    /** @var BusDriver */
+    private $busDriver;
+    /** @var SnsTransportNameResolver|null */
+    private $transportNameResolver;
 
     public function __construct(
         BusDriver $busDriver,
         MessageBusInterface $bus,
         SerializerInterface $serializer,
-        SnsTransportNameResolver $transportNameResolver,
-        string $transportName = null
+        string $transportName = null,
+        SnsTransportNameResolver $transportNameResolver = null,
     ) {
         $this->busDriver = $busDriver;
         $this->bus = $bus;
@@ -43,7 +45,16 @@ final class SnsConsumer extends SnsHandler
             $headers = isset($attributes['Headers']) ? $attributes['Headers']->getValue() : '[]';
             $envelope = $this->serializer->decode(['body' => $record->getMessage(), 'headers' => json_decode($headers, true)]);
 
-            $this->busDriver->putEnvelopeOnBus($this->bus, $envelope, $this->transportName ?? ($this->transportNameResolver)($record));
+            $this->busDriver->putEnvelopeOnBus($this->bus, $envelope, $this->resolveTransportName($record));
         }
+    }
+
+    private function resolveTransportName(SnsRecord $record): string
+    {
+        if (null === $this->transportName && null === $this->transportNameResolver) {
+            throw new LogicException('You need to set $transportNameResolver or $transportName.');
+        }
+
+        return $this->transportName ?? ($this->transportNameResolver)($record);
     }
 }

--- a/src/Service/Sns/SnsTransportNameResolver.php
+++ b/src/Service/Sns/SnsTransportNameResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service\Sns;
+
+use Bref\Event\Sns\SnsRecord;
+use Bref\Symfony\Messenger\Service\MessengerTransportConfiguration;
+use InvalidArgumentException;
+
+/** @final */
+class SnsTransportNameResolver
+{
+    private const TRANSPORT_PROTOCOL = 'sns://';
+
+    public function __construct(
+        private MessengerTransportConfiguration $configurationProvider
+    ) {
+    }
+
+    /** @throws InvalidArgumentException */
+    public function __invoke(SnsRecord $snsRecord): string
+    {
+        if (!array_key_exists('EventSubscriptionArn', $snsRecord->toArray())) {
+            throw new InvalidArgumentException('EventSubscriptionArn is missing in sns record.');
+        }
+
+        $eventSourceArn = $snsRecord->getEventSubscriptionArn();
+
+        return $this->configurationProvider->provideTransportFromEventSource(self::TRANSPORT_PROTOCOL . $eventSourceArn);
+    }
+}

--- a/src/Service/Sqs/SqsTransportNameResolver.php
+++ b/src/Service/Sqs/SqsTransportNameResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service\Sqs;
+
+use Bref\Event\Sqs\SqsRecord;
+use Bref\Symfony\Messenger\Service\MessengerTransportConfiguration;
+use InvalidArgumentException;
+
+/** @final */
+class SqsTransportNameResolver
+{
+    private const TRANSPORT_PROTOCOL = 'sqs://';
+
+    public function __construct(
+        private MessengerTransportConfiguration $configurationProvider
+    ) {
+    }
+
+    public function __invoke(SqsRecord $sqsRecord): string
+    {
+        if (!array_key_exists('eventSourceARN', $sqsRecord->toArray())) {
+            throw new InvalidArgumentException('EventSourceArn is missing in sqs record.');
+        }
+
+        $eventSourceArn = $sqsRecord->toArray()['eventSourceARN'];
+
+        return $this->configurationProvider->provideTransportFromEventSource(self::TRANSPORT_PROTOCOL . $eventSourceArn);
+    }
+}

--- a/tests/Unit/Service/MessengerTransportConfigurationTest.php
+++ b/tests/Unit/Service/MessengerTransportConfigurationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Test\Unit\Service;
+
+use Bref\Symfony\Messenger\Service\MessengerTransportConfiguration;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class MessengerTransportConfigurationTest extends TestCase
+{
+    public function test_existing_transport_will_be_found_with_existing_event_source_arn(): void
+    {
+        $messengerTransportConfiguration = new MessengerTransportConfiguration([
+            'async_example_one' => 'sqs://arn:aws:sqs:us-east-1:123456789012:example_one',
+            'async_example_two' => [
+                'dsn' => 'sqs://arn:aws:sqs:us-east-1:123456789012:example_two',
+            ],
+        ]);
+
+        self::assertSame(
+            'async_example_one',
+            $messengerTransportConfiguration->provideTransportFromEventSource(
+                'sqs://arn:aws:sqs:us-east-1:123456789012:example_one'
+            )
+        );
+
+        self::assertSame(
+            'async_example_two',
+            $messengerTransportConfiguration->provideTransportFromEventSource(
+                'sqs://arn:aws:sqs:us-east-1:123456789012:example_two'
+            )
+        );
+    }
+
+    public function test_non_existing_transport_for_event_source_arn_will_be_not_found(): void
+    {
+        $messengerTransportConfiguration = new MessengerTransportConfiguration([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'No transport found for eventSource "sqs://arn:aws:sqs:us-east-1:123456789012:missing".'
+        );
+
+        $messengerTransportConfiguration->provideTransportFromEventSource(
+            'sqs://arn:aws:sqs:us-east-1:123456789012:missing'
+        );
+    }
+}

--- a/tests/Unit/Service/Sns/SnsConsumerTest.php
+++ b/tests/Unit/Service/Sns/SnsConsumerTest.php
@@ -6,6 +6,7 @@ use Bref\Context\Context;
 use Bref\Event\Sns\SnsEvent;
 use Bref\Symfony\Messenger\Service\BusDriver;
 use Bref\Symfony\Messenger\Service\Sns\SnsConsumer;
+use Bref\Symfony\Messenger\Service\Sns\SnsTransportNameResolver;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
@@ -13,28 +14,115 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class SnsConsumerTest extends TestCase
 {
-    public function testSerializer()
+    private $busDriver;
+
+    private $serializer;
+
+    private MessageBus $bus;
+
+    private $snsTransportNameResolver;
+
+    /** @before */
+    public function before(): void
     {
-        $busDriver = $this->getMockBuilder(BusDriver::class)
+        $this->busDriver = $this->getMockBuilder(BusDriver::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['putEnvelopeOnBus'])
             ->getMock();
-        $bus = new MessageBus;
-        $serializer = $this->getMockBuilder(SerializerInterface::class)
+
+        $this->bus = new MessageBus;
+
+        $this->serializer = $this->getMockBuilder(SerializerInterface::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['encode', 'decode'])
             ->getMock();
 
+        $this->snsTransportNameResolver = $this->getMockBuilder(SnsTransportNameResolver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function test_serializer()
+    {
         $headers = ['Content-Type' => 'application/json'];
         $body = 'Test message.';
 
-        $serializer->expects($this->once())
+        $this->serializer->expects($this->once())
             ->method('decode')
             ->with(['body' => $body, 'headers' => $headers])
             ->willReturn(new Envelope(new \stdClass));
 
-        $consumer = new SnsConsumer($busDriver, $bus, $serializer, 'async');
-        $event = new SnsEvent([
+        $this->snsTransportNameResolver->expects($this->once())
+            ->method('__invoke')
+            ->willReturn('async');
+
+        $consumer = new SnsConsumer(
+            $this->busDriver,
+            $this->bus,
+            $this->serializer,
+            $this->snsTransportNameResolver
+        );
+
+        $event = $this->snsEvent($body, $headers);
+
+        $consumer->handleSns($event, new Context('', 0, '', ''));
+    }
+
+    public function test_event_with_transport_detection(): void
+    {
+        $headers = ['Content-Type' => 'application/json'];
+        $body = 'Test message.';
+
+        $this->serializer->expects($this->once())
+            ->method('decode')
+            ->with(['body' => $body, 'headers' => $headers])
+            ->willReturn(new Envelope(new \stdClass));
+
+        $this->snsTransportNameResolver->expects($this->once())
+            ->method('__invoke')
+            ->willReturn('async');
+
+        $consumer = new SnsConsumer(
+            $this->busDriver,
+            $this->bus,
+            $this->serializer,
+            $this->snsTransportNameResolver
+        );
+
+        $event = $this->snsEvent($body, $headers);
+
+        $consumer->handleSns($event, new Context('', 0, '', ''));
+    }
+
+    public function test_event_with_manually_set_transport(): void
+    {
+        $headers = ['Content-Type' => 'application/json'];
+        $body = 'Test message.';
+
+        $this->serializer->expects($this->once())
+            ->method('decode')
+            ->with(['body' => $body, 'headers' => $headers])
+            ->willReturn(new Envelope(new \stdClass));
+
+        $this->snsTransportNameResolver->expects($this->never())
+            ->method('__invoke');
+
+        $consumer = new SnsConsumer(
+            $this->busDriver,
+            $this->bus,
+            $this->serializer,
+            $this->snsTransportNameResolver,
+            'async'
+        );
+
+        $event = $this->snsEvent($body, $headers);
+
+        $consumer->handleSns($event, new Context('', 0, '', ''));
+    }
+
+    private function snsEvent(string $body, array $headers): SnsEvent
+    {
+        return new SnsEvent([
             'Records' => [
                 [
 
@@ -51,7 +139,5 @@ class SnsConsumerTest extends TestCase
                 ],
             ],
         ]);
-
-        $consumer->handleSns($event, new Context('', 0, '', ''));
     }
 }

--- a/tests/Unit/Service/Sns/SnsConsumerTest.php
+++ b/tests/Unit/Service/Sns/SnsConsumerTest.php
@@ -7,6 +7,7 @@ use Bref\Event\Sns\SnsEvent;
 use Bref\Symfony\Messenger\Service\BusDriver;
 use Bref\Symfony\Messenger\Service\Sns\SnsConsumer;
 use Bref\Symfony\Messenger\Service\Sns\SnsTransportNameResolver;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
@@ -60,6 +61,7 @@ class SnsConsumerTest extends TestCase
             $this->busDriver,
             $this->bus,
             $this->serializer,
+            null,
             $this->snsTransportNameResolver
         );
 
@@ -86,6 +88,7 @@ class SnsConsumerTest extends TestCase
             $this->busDriver,
             $this->bus,
             $this->serializer,
+            null,
             $this->snsTransportNameResolver
         );
 
@@ -111,8 +114,8 @@ class SnsConsumerTest extends TestCase
             $this->busDriver,
             $this->bus,
             $this->serializer,
-            $this->snsTransportNameResolver,
-            'async'
+            'async',
+            $this->snsTransportNameResolver
         );
 
         $event = $this->snsEvent($body, $headers);

--- a/tests/Unit/Service/Sns/SnsTransportNameResolverTest.php
+++ b/tests/Unit/Service/Sns/SnsTransportNameResolverTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Test\Unit\Service\Sns;
+
+use Bref\Event\Sns\SnsEvent;
+use Bref\Symfony\Messenger\Service\MessengerTransportConfiguration;
+use Bref\Symfony\Messenger\Service\Sns\SnsTransportNameResolver;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class SnsTransportNameResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function test_event_source_can_resolved_as_expected(): void
+    {
+        $messengerTransportConfiguration = $this->prophesize(MessengerTransportConfiguration::class);
+        $messengerTransportConfiguration
+            ->provideTransportFromEventSource(Argument::cetera())
+            ->willReturn('async');
+
+        $transportNameResolver = new SnsTransportNameResolver($messengerTransportConfiguration->reveal());
+
+        $event = new SnsEvent([
+            'Records' => [
+                [
+
+                    'EventSource'=>'aws:sns',
+                    'EventSubscriptionArn' => 'arn:aws:sns:us-east-1:1234567890:async',
+                    'Sns' => [
+                        'Message' => 'Test message.',
+                        'MessageAttributes' => [
+                            'Headers' => [
+                                'Type'=> 'String',
+                                'Value'=> ['Content-Type' => 'application/json'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame('async', ($transportNameResolver)($event->getRecords()[0]));
+    }
+}

--- a/tests/Unit/Service/Sqs/SqsConsumerTest.php
+++ b/tests/Unit/Service/Sqs/SqsConsumerTest.php
@@ -63,7 +63,15 @@ class SqsConsumerTest extends TestCase
             ),
         ];
 
-        $consumer = new SqsConsumer($this->busDriver->reveal(), $this->bus, $this->serializer->reveal(), $this->sqsTransportNameResolver->reveal());
+        $consumer = new SqsConsumer(
+            $this->busDriver->reveal(),
+            $this->bus,
+            $this->serializer->reveal(),
+            null,
+            null,
+            false,
+            $this->sqsTransportNameResolver->reveal()
+        );
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
         $this->assertEmpty($failures);
     }
@@ -84,6 +92,9 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            null,
+            null,
+            false,
             $this->sqsTransportNameResolver->reveal()
         );
 
@@ -108,8 +119,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            'async_test',
+            null,
+            false,
             $this->sqsTransportNameResolver->reveal(),
-            'async_test'
         );
 
         $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
@@ -143,6 +156,9 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            $transport,
+            null,
+            false,
             $this->sqsTransportNameResolver->reveal()
         );
 
@@ -178,10 +194,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
-            $this->sqsTransportNameResolver->reveal(),
             null,
             null,
-            true
+            true,
+            $this->sqsTransportNameResolver->reveal()
         );
 
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
@@ -221,10 +237,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
-            $this->sqsTransportNameResolver->reveal(),
+            $transport,
             null,
-            null,
-            true
+            true,
+            $this->sqsTransportNameResolver->reveal()
         );
 
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
@@ -266,6 +282,9 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            $transport,
+            null,
+            false,
             $this->sqsTransportNameResolver->reveal()
         );
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', $xrayTraceId));
@@ -305,10 +324,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            $transport,
+            null,
+            true,
             $this->sqsTransportNameResolver->reveal(),
-            null,
-            null,
-            true
         );
 
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
@@ -356,10 +375,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            $transport,
+            null,
+            true,
             $this->sqsTransportNameResolver->reveal(),
-            null,
-            null,
-            true
         );
 
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));
@@ -410,10 +429,10 @@ class SqsConsumerTest extends TestCase
             $this->busDriver->reveal(),
             $this->bus,
             $this->serializer->reveal(),
+            $transport,
+            null,
+            true,
             $this->sqsTransportNameResolver->reveal(),
-            null,
-            null,
-            true
         );
 
         $failures = $consumer->handle(['Records' => $sqsRecords], new Context('', 0, '', ''));


### PR DESCRIPTION
Hello :)

This will resolve #83

I thought it might be a good idea to parse the transports mapping in the `messenger.yaml` and map the transport with the eventSourceARN of a sqsEvent or the EventSubscriptionArn of a snsEvent with the configured transport.

With this solution the `$transportName` is not required anymore and I don't need to create one lambda per sqs queue for my use case :) Would be great if you can take a look at this @mnapoli 