### PR TITLE
Get the eventSourceArn from $snsRecord->getTopicArn instead of getEve…

### DIFF
--- a/src/Service/Sns/SnsTransportNameResolver.php
+++ b/src/Service/Sns/SnsTransportNameResolver.php
@@ -19,11 +19,11 @@ class SnsTransportNameResolver
     /** @throws InvalidArgumentException */
     public function __invoke(SnsRecord $snsRecord): string
     {
-        if (!array_key_exists('EventSubscriptionArn', $snsRecord->toArray())) {
-            throw new InvalidArgumentException('EventSubscriptionArn is missing in sns record.');
+        if (!array_key_exists('TopicArn', $snsRecord->toArray()['Sns'])) {
+            throw new InvalidArgumentException('TopicArn is missing in sns record.');
         }
 
-        $eventSourceArn = $snsRecord->getEventSubscriptionArn();
+        $eventSourceArn = $snsRecord->getTopicArn();
 
         return $this->configurationProvider->provideTransportFromEventSource(self::TRANSPORT_PROTOCOL . $eventSourceArn);
     }

--- a/tests/Unit/Service/Sns/SnsTransportNameResolverTest.php
+++ b/tests/Unit/Service/Sns/SnsTransportNameResolverTest.php
@@ -5,6 +5,7 @@ namespace Bref\Symfony\Messenger\Test\Unit\Service\Sns;
 use Bref\Event\Sns\SnsEvent;
 use Bref\Symfony\Messenger\Service\MessengerTransportConfiguration;
 use Bref\Symfony\Messenger\Service\Sns\SnsTransportNameResolver;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -26,9 +27,38 @@ final class SnsTransportNameResolverTest extends TestCase
         $event = new SnsEvent([
             'Records' => [
                 [
-
                     'EventSource'=>'aws:sns',
-                    'EventSubscriptionArn' => 'arn:aws:sns:us-east-1:1234567890:async',
+                    'Sns' => [
+                        'Message' => 'Test message.',
+                        'MessageAttributes' => [
+                            'Headers' => [
+                                'Type'=> 'String',
+                                'Value'=> ['Content-Type' => 'application/json'],
+                            ],
+                        ],
+                        'TopicArn' => 'arn:aws:sns:us-east-1:1234567890:async',
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame('async', ($transportNameResolver)($event->getRecords()[0]));
+    }
+
+    public function test_throws_exception_if_topic_arn_deos_not_exist(): void
+    {
+        $messengerTransportConfiguration = $this->prophesize(MessengerTransportConfiguration::class);
+        /** @phpstan-ignore-next-line */
+        $messengerTransportConfiguration
+            ->provideTransportFromEventSource(Argument::cetera())
+            ->willReturn('async');
+
+        $transportNameResolver = new SnsTransportNameResolver($messengerTransportConfiguration->reveal());
+
+        $eventWithMissingTopicArn = new SnsEvent([
+            'Records' => [
+                [
+                    'EventSource'=>'aws:sns',
                     'Sns' => [
                         'Message' => 'Test message.',
                         'MessageAttributes' => [
@@ -42,6 +72,7 @@ final class SnsTransportNameResolverTest extends TestCase
             ],
         ]);
 
-        self::assertSame('async', ($transportNameResolver)($event->getRecords()[0]));
+        $this->expectException(InvalidArgumentException::class);
+        ($transportNameResolver)($eventWithMissingTopicArn->getRecords()[0]);
     }
 }


### PR DESCRIPTION
Hi,

While trying to consume SNS events, I encountered the error `No transport found for eventSource` in `\Bref\Symfony\Messenger\Service\MessengerTransportConfiguration`. Upon investigation, I discovered that the `$eventSourceArn` passed to the `provideTransportFromEventSource` method includes a `MessageId`, resulting in an ARN like `sns://arn:aws:sns:eu-central-1:account-id:sns-topic-name:9d572d5f-a88c-49df-9f61-81270fdb55fc`. 

Since each event has a different MessageId, this always triggers the `No transport found for eventSource` error.

This PR addresses the issue by using `$snsRecord->getTopicArn()` instead of `$snsRecord->getEventSubscriptionArn()`.

@mnapoli. I would greatly appreciate it if you could review this PR, as this issue is a blocker for consuming SNS events in our project.