### PR TITLE
fix: Set messenger.transports if config has not empty transports value

### DIFF
--- a/src/DependencyInjection/BrefMessengerExtension.php
+++ b/src/DependencyInjection/BrefMessengerExtension.php
@@ -18,12 +18,23 @@ class BrefMessengerExtension extends Extension implements PrependExtensionInterf
 
     public function prepend(ContainerBuilder $container): void
     {
-        $configs = $container->getExtensionConfig('framework');
+        $frameworkConfig = $container->getExtensionConfig('framework');
+        $messengerTransports = $this->getMessengerTransports($frameworkConfig);
 
-        foreach (array_reverse($configs) as $config) {
-            if (array_key_exists('messenger', $config)) {
-                $container->setParameter('messenger.transports', $config['messenger']['transports']);
-            }
+        if (! empty($messengerTransports)) {
+            $container->setParameter('messenger.transports', $messengerTransports);
         }
+    }
+
+    private function getMessengerTransports(array $frameworkConfig): array
+    {
+        $transportConfigs = array_column($frameworkConfig, 'messenger.transports');
+        $transportConfigs = array_filter($transportConfigs);
+
+        if (empty($transportConfigs)) {
+            return [];
+        }
+
+        return array_merge_recursive(...$transportConfigs);
     }
 }

--- a/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
+++ b/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
@@ -5,6 +5,7 @@ namespace Bref\Symfony\Messenger\Test\Unit\DependencyInjection;
 use Bref\Symfony\Messenger\DependencyInjection\BrefMessengerExtension;
 use Bref\Symfony\Messenger\Service\SimpleBusDriver;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class BrefMessengerExtensionTest extends AbstractExtensionTestCase
 {
@@ -18,5 +19,243 @@ class BrefMessengerExtensionTest extends AbstractExtensionTestCase
         $this->load();
 
         $this->assertContainerBuilderHasService(SimpleBusDriver::class);
+    }
+
+    /**
+     * @dataProvider providePrependSetsMessengerTransportsParameterCases
+     */
+    public function testPrependSetsMessengerTransportsParameter(
+        array $existConfig,
+        array $expectedTransportsParameter,
+    ): void {
+        $container = self::createMock(ContainerBuilder::class);
+        $container->method('getExtensionConfig')
+            ->with('framework')
+            ->willReturn($existConfig);
+
+        $container->expects(self::atMost(2))
+            ->method('setParameter')
+            ->with(
+                'messenger.transports',
+                $expectedTransportsParameter
+            );
+
+        $extension = new BrefMessengerExtension;
+        $extension->prepend($container);
+    }
+
+    public function providePrependSetsMessengerTransportsParameterCases(): iterable
+    {
+        yield 'single messenger config' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async://',
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'async' => 'async://',
+            ],
+        ];
+
+        yield 'multiple messenger configs' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'sync' => 'sync://',
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'async' => 'async://',
+                'sync' => 'sync://',
+            ],
+        ];
+
+        yield 'multiple messenger configs with same transport' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async_overridden://',
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'async' => 'async_overridden://',
+            ],
+        ];
+
+        yield 'multiple messenger configs with different transports' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'sync' => 'sync://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => 'async_overridden://',
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'async' => 'async_overridden://',
+                'sync' => 'sync://',
+            ],
+        ];
+
+        yield 'multiple messenger configs with different transports order' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'sync' => 'sync://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => [
+                                'dsn' => 'async://',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => [
+                                'dsn' => 'async_overridden://',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'sync' => 'sync://',
+                'async' => [
+                    'dsn' => 'async_overridden://',
+                ],
+            ],
+        ];
+
+        yield 'multiple messenger configs with different transports order and extra keys' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'sync' => 'sync://',
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => [
+                                'dsn' => 'async://',
+                                'options' => [
+                                    'queue' => 'queue',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'messenger' => [
+                        'transports' => [
+                            'async' => [
+                                'dsn' => 'async_overridden://',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'expectedTransportsParameter' => [
+                'sync' => 'sync://',
+                'async' => [
+                    'dsn' => 'async_overridden://',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDoesNotSetMessengerTransportsParameterCases
+     */
+    public function testPrependDoesNotSetMessengerTransportsParameterWhenNoMessengerConfigExists(
+        array $config,
+    ): void {
+        $container = self::createMock(ContainerBuilder::class);
+        $container->method('getExtensionConfig')
+            ->with('framework')
+            ->willReturn($config);
+
+        $container->expects(self::never())->method('setParameter');
+
+        $extension = new BrefMessengerExtension;
+        $extension->prepend($container);
+    }
+
+    public function provideDoesNotSetMessengerTransportsParameterCases(): iterable
+    {
+        yield 'empty config' => [
+            'config' => [],
+        ];
+
+        yield 'empty messenger config' => [
+            'config' => [
+                'messenger' => [],
+            ],
+        ];
+
+        yield 'not empty messenger config without transports key' => [
+            'config' => [
+                'messenger' => [
+                    'busses' => [],
+                ],
+            ],
+        ];
+
+        yield 'not empty messenger config with empty transports key' => [
+            'config' => [
+                'messenger' => [
+                    'transports' => [],
+                    'busses' => [],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
These changes fix the issue in `BrefMessengerExtension::prepand()` for applications with multiple configs in different environments.
```
In BrefMessengerExtension.php line 25:

Warning: Undefined array key "transports"
```
Example:
```
configs
|__ packages
    |__dev
    |    |__messenger.yaml
    |__prod
    |    |__messenger.yaml
    |__messenger.yaml     
```
```
# configs/messenger.yaml
...
framework:
    messenger:
        transports:
            default_bus:
                <transport-config>
        routing:
            App\Message\Message: default_bus
```
```
# configs/dev/messenger.yaml
...
framework:
    messenger:
        buses:
            <dev-buses-config>
```
```
# configs/prod/messenger.yaml
...
framework:
    messenger:
        buses:
            <prod-buses-config>
```