### PR TITLE
hotfix: not fount messenger.transport parameter

### DIFF
--- a/src/DependencyInjection/BrefMessengerExtension.php
+++ b/src/DependencyInjection/BrefMessengerExtension.php
@@ -28,13 +28,16 @@ class BrefMessengerExtension extends Extension implements PrependExtensionInterf
 
     private function getMessengerTransports(array $frameworkConfig): array
     {
-        $transportConfigs = array_column($frameworkConfig, 'messenger.transports');
+        $transportConfigs = array_column(
+            array_column($frameworkConfig, 'messenger'),
+            'transports',
+        );
         $transportConfigs = array_filter($transportConfigs);
 
         if (empty($transportConfigs)) {
             return [];
         }
 
-        return array_merge_recursive(...$transportConfigs);
+        return array_merge(...$transportConfigs);
     }
 }

--- a/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
+++ b/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
@@ -33,7 +33,7 @@ class BrefMessengerExtensionTest extends AbstractExtensionTestCase
             ->with('framework')
             ->willReturn($existConfig);
 
-        $container->expects(self::atMost(2))
+        $container->expects(self::once())
             ->method('setParameter')
             ->with(
                 'messenger.transports',


### PR DESCRIPTION
After the last changes in [PR](https://github.com/brefphp/symfony-messenger/pull/90), throw new exception 
```
In DefinitionErrorExceptionPass.php line 51:
  You have requested a non-existent parameter "messenger.transports".
```