### PR TITLE
bugfix: Set up empty messenger.transports parameter

### DIFF
--- a/src/DependencyInjection/BrefMessengerExtension.php
+++ b/src/DependencyInjection/BrefMessengerExtension.php
@@ -21,9 +21,7 @@ class BrefMessengerExtension extends Extension implements PrependExtensionInterf
         $frameworkConfig = $container->getExtensionConfig('framework');
         $messengerTransports = $this->getMessengerTransports($frameworkConfig);
 
-        if (! empty($messengerTransports)) {
-            $container->setParameter('messenger.transports', $messengerTransports);
-        }
+        $container->setParameter('messenger.transports', $messengerTransports);
     }
 
     private function getMessengerTransports(array $frameworkConfig): array

--- a/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
+++ b/tests/Unit/DependencyInjection/BrefMessengerExtensionTest.php
@@ -210,52 +210,28 @@ class BrefMessengerExtensionTest extends AbstractExtensionTestCase
                 ],
             ],
         ];
-    }
 
-    /**
-     * @dataProvider provideDoesNotSetMessengerTransportsParameterCases
-     */
-    public function testPrependDoesNotSetMessengerTransportsParameterWhenNoMessengerConfigExists(
-        array $config,
-    ): void {
-        $container = self::createMock(ContainerBuilder::class);
-        $container->method('getExtensionConfig')
-            ->with('framework')
-            ->willReturn($config);
-
-        $container->expects(self::never())->method('setParameter');
-
-        $extension = new BrefMessengerExtension;
-        $extension->prepend($container);
-    }
-
-    public function provideDoesNotSetMessengerTransportsParameterCases(): iterable
-    {
-        yield 'empty config' => [
-            'config' => [],
-        ];
-
-        yield 'empty messenger config' => [
-            'config' => [
-                'messenger' => [],
-            ],
-        ];
-
-        yield 'not empty messenger config without transports key' => [
-            'config' => [
-                'messenger' => [
-                    'busses' => [],
+        yield 'empty transports config when messenger only consuming messages' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [],
+                    ],
                 ],
             ],
+            'expectedTransportsParameter' => [],
         ];
 
-        yield 'not empty messenger config with empty transports key' => [
-            'config' => [
-                'messenger' => [
-                    'transports' => [],
-                    'busses' => [],
+        yield 'multiple messenger configs with empty transports key when messenger only consuming messages' => [
+            'existConfig' => [
+                [
+                    'messenger' => [
+                        'transports' => [],
+                        'busses' => [],
+                    ],
                 ],
             ],
+            'expectedTransportsParameter' => [],
         ];
     }
 }


### PR DESCRIPTION
When your app just install messenger with empty config or your app is not provide messages to transport (only consumining).
Example:
```
# configs/messenger.yaml

framework:
    messenger:
        transports: []
        routing:
            # Route your messages to the transports

```