### PR TITLE
Removed deprecations for PHP 8.4

### DIFF
--- a/src/Service/EventBridge/EventBridgeTransport.php
+++ b/src/Service/EventBridge/EventBridgeTransport.php
@@ -6,7 +6,6 @@ use AsyncAws\EventBridge\EventBridgeClient;
 use Exception;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
-use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Throwable;

--- a/src/Service/Sns/SnsConsumer.php
+++ b/src/Service/Sns/SnsConsumer.php
@@ -28,8 +28,8 @@ final class SnsConsumer extends SnsHandler
         BusDriver $busDriver,
         MessageBusInterface $bus,
         SerializerInterface $serializer,
-        string $transportName = null,
-        SnsTransportNameResolver $transportNameResolver = null,
+        ?string $transportName = null,
+        ?SnsTransportNameResolver $transportNameResolver = null,
     ) {
         $this->busDriver = $busDriver;
         $this->bus = $bus;

--- a/src/Service/Sns/SnsFifoStamp.php
+++ b/src/Service/Sns/SnsFifoStamp.php
@@ -8,7 +8,7 @@ class SnsFifoStamp implements NonSendableStampInterface {
     private ?string $messageGroupId;
     private ?string $messageDeduplicationId;
 
-    public function __construct(string $messageGroupId = null, string $messageDeduplicationId = null)
+    public function __construct(?string $messageGroupId = null, ?string $messageDeduplicationId = null)
     {
         $this->messageGroupId = $messageGroupId;
         $this->messageDeduplicationId = $messageDeduplicationId;

--- a/src/Service/Sns/SnsTransport.php
+++ b/src/Service/Sns/SnsTransport.php
@@ -7,7 +7,6 @@ use AsyncAws\Sns\ValueObject\MessageAttributeValue;
 use Exception;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
-use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Throwable;

--- a/src/Service/Sqs/SqsConsumer.php
+++ b/src/Service/Sqs/SqsConsumer.php
@@ -2,6 +2,7 @@
 
 namespace Bref\Symfony\Messenger\Service\Sqs;
 
+use Throwable;
 use Bref\Context\Context;
 use Bref\Event\Sqs\SqsEvent;
 use Bref\Event\Sqs\SqsHandler;
@@ -39,10 +40,10 @@ final class SqsConsumer extends SqsHandler
         BusDriver $busDriver,
         MessageBusInterface $bus,
         SerializerInterface $serializer,
-        string $transportName = null,
-        LoggerInterface $logger = null,
+        ?string $transportName = null,
+        ?LoggerInterface $logger = null,
         bool $partialBatchFailure = false,
-        SqsTransportNameResolver $transportNameResolver = null
+        ?SqsTransportNameResolver $transportNameResolver = null
     ) {
         $this->busDriver = $busDriver;
         $this->bus = $bus;
@@ -102,7 +103,7 @@ final class SqsConsumer extends SqsHandler
             } catch (UnrecoverableExceptionInterface $exception) {
                 $this->logger->error(sprintf('SQS record with id "%s" failed to be processed. But failure was marked as unrecoverable. Message will be acknowledged.', $record->getMessageId()));
                 $this->logger->error($exception);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
                 if ($this->partialBatchFailure === false) {
                     throw $exception;
                 }


### PR DESCRIPTION
Removes deprecations which are raised in the update to PHP 8.4 (vars which have a null-value default should be nullable in the function params).

I just ran 'rector' over the repo, which also removed an usused import, and imported the Throwable class.

This is related to issue #93 
Cheers, and thank you again for all your work on this repo @mnapoli  :)