### PR TITLE
Improve SQS Transport Resolver to match standard configuration

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -20,9 +20,13 @@ services:
         class: AsyncAws\Sns\SnsClient
 
     # SQS
+    Bref\Symfony\Messenger\Service\Sqs\SQSMessengerTransportConfiguration:
+        arguments:
+            $messengerTransportsConfiguration: '%messenger.transports%'
+
     Bref\Symfony\Messenger\Service\Sqs\SqsTransportNameResolver:
         arguments:
-            - '@Bref\Symfony\Messenger\Service\MessengerTransportConfiguration'
+            - '@Bref\Symfony\Messenger\Service\Sqs\SQSMessengerTransportConfiguration'
 
     # EventBridge
     Bref\Symfony\Messenger\Service\EventBridge\EventBridgeTransportFactory:

--- a/src/Service/Sqs/SQSMessengerTransportConfiguration.php
+++ b/src/Service/Sqs/SQSMessengerTransportConfiguration.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bref\Symfony\Messenger\Service\Sqs;
+
+use InvalidArgumentException;
+
+final class SQSMessengerTransportConfiguration
+{
+    public function __construct(
+        private array $messengerTransportsConfiguration
+    ) {
+    }
+
+    /** @throws InvalidArgumentException */
+    public function provideTransportFromEventSource(string $eventSourceWithProtocol): string
+    {
+        foreach ($this->messengerTransportsConfiguration as $messengerTransport => $messengerOptions) {
+            $dsn = $this->extractDsnFromTransport($messengerOptions);
+
+            if ($dsn === $eventSourceWithProtocol) {
+                return $messengerTransport;
+            }
+
+            // Rebuild SQS ARN from https://sqs.eu-west-3.amazonaws.com/0123456789/messages?key=value
+            if (preg_match('/^https:\/\/sqs\.([^.]+)\.amazonaws\.com\/([^\/]+)\/([^?]+)/', (string) $dsn, $matches)) {
+                $arn = 'arn:aws:sqs:'.$matches[1].':'.$matches[2].':'.$matches[3];
+
+                if($eventSourceWithProtocol == 'sqs://' . $arn){
+                    return $messengerTransport;
+                }
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf('No transport found for eventSource "%s".', $eventSourceWithProtocol));
+    }
+
+    private function extractDsnFromTransport(string|array $messengerTransport): string
+    {
+        if (is_array($messengerTransport) && array_key_exists('dsn', $messengerTransport)) {
+            return $messengerTransport['dsn'];
+        }
+
+        return $messengerTransport;
+    }
+}

--- a/src/Service/Sqs/SqsTransportNameResolver.php
+++ b/src/Service/Sqs/SqsTransportNameResolver.php
@@ -12,7 +12,7 @@ class SqsTransportNameResolver
     private const TRANSPORT_PROTOCOL = 'sqs://';
 
     public function __construct(
-        private MessengerTransportConfiguration $configurationProvider
+        private SQSMessengerTransportConfiguration $configurationProvider
     ) {
     }
 


### PR DESCRIPTION
This PR updates the transport resolution logic to support SQS DSNs formatted according to the Symfony documentation (e.g., https://sqs.eu-west-3.amazonaws.com/123456789012/messages). This allows seamless configuration when using multiple SQS queues and transports.